### PR TITLE
[ch7688] allow customizing behaviour of merging and saving merged specs

### DIFF
--- a/src/Commands/BaseDocsCommand.php
+++ b/src/Commands/BaseDocsCommand.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Foodkit\OpenApiDto\Commands;
 
 use Foodkit\OpenApiDto\Managers\DocsManager;
-use Foodkit\OpenApiDto\Resolvers\DocsResolver;
+use Foodkit\OpenApiDto\Resolvers\RoutesResolver;
 use Illuminate\Console\Command;
 use Illuminate\Routing\Route;
 
@@ -17,8 +17,8 @@ abstract class BaseDocsCommand extends Command
     /** @var \Illuminate\Support\Collection|Route[] $routes */
     protected $routes;
 
-    /** @var DocsResolver $docsResolver */
-    protected $docsResolver;
+    /** @var RoutesResolver $routesResolver */
+    protected $routesResolver;
 
     /** @var DocsManager $docsManager */
     protected $docsManager;
@@ -28,7 +28,7 @@ abstract class BaseDocsCommand extends Command
         parent::__construct();
 
         $this->routes = collect(\Illuminate\Support\Facades\Route::getRoutes()->getRoutes());
-        $this->docsResolver = new DocsResolver($this->routes);
+        $this->routesResolver = new RoutesResolver($this->routes);
         $this->docsManager = new DocsManager();
     }
 

--- a/src/Commands/BuildSpecs.php
+++ b/src/Commands/BuildSpecs.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Foodkit\OpenApiDto\Commands;
 
-use Foodkit\OpenApiDto\Builders\DocsBuilder;
+use Foodkit\OpenApiDto\Builders\SpecsBuilder;
 use Foodkit\OpenApiDto\Resolvers\SpecsResolver;
 
 class BuildSpecs extends BaseDocsCommand
@@ -23,7 +23,7 @@ class BuildSpecs extends BaseDocsCommand
      */
     protected $description = 'Builds Open API compatible specs from app\'s route definitions';
 
-    /** @var DocsBuilder $docsBuilder */
+    /** @var SpecsBuilder $docsBuilder */
     protected $docsBuilder;
 
     /**
@@ -32,7 +32,7 @@ class BuildSpecs extends BaseDocsCommand
     public function __construct()
     {
         parent::__construct();
-        $this->docsBuilder = new DocsBuilder($this->docsResolver, new SpecsResolver());
+        $this->docsBuilder = new SpecsBuilder($this->routesResolver, new SpecsResolver());
     }
 
     /**
@@ -68,11 +68,11 @@ class BuildSpecs extends BaseDocsCommand
      */
     protected function buildDocs(int $version): void
     {
-        $versionedRoutes = $this->docsResolver->resolveRoutesForVersion($version);
-        $groupedRoutes = $this->docsResolver->groupRoutes($versionedRoutes);
+        $versionedRoutes = $this->routesResolver->resolveRoutesForVersion($version);
+        $groupedRoutes = $this->routesResolver->groupRoutes($versionedRoutes);
 
         foreach ($groupedRoutes as $uri => $routes) {
-            $docs = $this->docsBuilder->buildDocs($routes);
+            $docs = $this->docsBuilder->buildSpecs($routes);
 
             if (!count($docs)) {
                 continue;

--- a/src/Commands/CheckDocs.php
+++ b/src/Commands/CheckDocs.php
@@ -81,8 +81,8 @@ class CheckDocs extends BaseDocsCommand
      */
     public function checkDocs(int $version): bool
     {
-        $versionedRoutes = $this->docsResolver->resolveRoutesForVersion($version);
-        $groupedRoutes = $this->docsResolver->groupRoutes($versionedRoutes);
+        $versionedRoutes = $this->routesResolver->resolveRoutesForVersion($version);
+        $groupedRoutes = $this->routesResolver->groupRoutes($versionedRoutes);
 
         $coverage = [
             'documented' => 0,
@@ -124,7 +124,7 @@ class CheckDocs extends BaseDocsCommand
         foreach ($routes as $route) {
             /** @var Route $route */
             if (!$this->routeIsAnnotated($route)) {
-                $this->warn("[".$this->docsResolver->resolveDocsPathMethod($route)."] ".$this->docsResolver->resolveDocsPathUri($route).' route is not annotated');
+                $this->warn("[".$this->routesResolver->resolveDocsPathMethod($route)."] ".$this->routesResolver->resolveDocsPathUri($route).' route is not annotated');
                 continue;
             }
 
@@ -183,8 +183,8 @@ class CheckDocs extends BaseDocsCommand
      */
     protected function routeIsDocumented(Route $route, array $docs): bool
     {
-        $routePathDescriptor = Arr::get($docs['paths'], $this->docsResolver->resolveDocsPathUri($route));
+        $routePathDescriptor = Arr::get($docs['paths'], $this->routesResolver->resolveDocsPathUri($route));
 
-        return $routePathDescriptor && Arr::has($routePathDescriptor, $this->docsResolver->resolveDocsPathMethod($route));
+        return $routePathDescriptor && Arr::has($routePathDescriptor, $this->routesResolver->resolveDocsPathMethod($route));
     }
 }

--- a/src/Commands/MakeSpecs.php
+++ b/src/Commands/MakeSpecs.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Foodkit\OpenApiDto\Commands;
 
-use Foodkit\OpenApiDto\Resolvers\DocsResolver;
+use Foodkit\OpenApiDto\Resolvers\RoutesResolver;
 use Illuminate\Console\Command;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Facades\File;
@@ -34,7 +34,7 @@ class MakeSpecs extends Command
     public function __construct()
     {
         parent::__construct();
-        $this->docsResolver = new DocsResolver(collect(\Illuminate\Support\Facades\Route::getRoutes()->getRoutes()));
+        $this->docsResolver = new RoutesResolver(collect(\Illuminate\Support\Facades\Route::getRoutes()->getRoutes()));
     }
 
     /**

--- a/src/Commands/PublishDocs.php
+++ b/src/Commands/PublishDocs.php
@@ -48,15 +48,17 @@ class PublishDocs extends BaseDocsCommand
     protected function publishDocs(int $version): void
     {
         $template = File::get(base_path('./docs/template.html'));
+        $mergedSpecFilePaths = File::glob(base_path("docs/v6/*.json"));
 
-        $publicDocs = $this->docsManager->loadDocs("v{$version}/public");
-        $privateDocs = $this->docsManager->loadDocs("v{$version}/private");
+        foreach ($mergedSpecFilePaths as $mergedSpecFilePath) {
+            $filename = basename($mergedSpecFilePath);
+            $name = explode('.', $filename)[0];
 
-        $renderedPublicDocs = $this->renderDocs($publicDocs, $template);
-        $renderedPrivateDocs = $this->renderDocs($privateDocs, $template);
+            $publicDocs = $this->docsManager->loadDocs("v{$version}/{$name}");
+            $renderedPublicDocs = $this->renderDocs($publicDocs, $template);
 
-        File::put(base_path("./docs/build/v{$version}-public.html"), $renderedPublicDocs);
-        File::put(base_path("./docs/build/v{$version}-private.html"), $renderedPrivateDocs);
+            File::put(base_path("./docs/build/v{$version}-{$name}.html"), $renderedPublicDocs);
+        }
 
         $this->info("Documentation for API version {$version} has been published.");
     }

--- a/src/Definitions/RequestDefinition.php
+++ b/src/Definitions/RequestDefinition.php
@@ -11,10 +11,6 @@ abstract class RequestDefinition
 {
     use MergesSchemas, ValidatesDefinitions;
 
-    public const MODIFIER_PUBLIC = 'modifier.public';
-    public const MODIFIER_PRIVATE = 'modifier.private';
-    public const MODIFIER_SKIP = 'modifier.skip';
-
     public function __construct()
     {
         $this->validateDefinitions($this->bodyParameters(), 'body');
@@ -67,11 +63,6 @@ abstract class RequestDefinition
     public function deprecated(): bool
     {
         return false;
-    }
-
-    public function modifier(): string
-    {
-        return self::MODIFIER_PUBLIC;
     }
 
     abstract public function tags(): array;

--- a/src/OpenApi.php
+++ b/src/OpenApi.php
@@ -1,0 +1,71 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Foodkit\OpenApiDto;
+
+class OpenApi
+{
+    /** @var array $tags */
+    protected $tags = [];
+
+    /** @var callable|null $mergeCallback */
+    protected $mergeCallback;
+
+    /** @var callable|null $mergedSpecsSaveCallback */
+    protected $mergedSpecsSaveCallback;
+
+    /**
+     * @param array $tags
+     * @return OpenApi
+     */
+    public function setTags(array $tags): OpenApi
+    {
+        $this->tags = $tags;
+        return $this;
+    }
+
+    /**
+     * @return array
+     */
+    public function getTags(): array
+    {
+        return $this->tags;
+    }
+
+    /**
+     * @param callable $mergeCallback
+     * @return OpenApi
+     */
+    public function setMergeCallback(callable $mergeCallback): OpenApi
+    {
+        $this->mergeCallback = $mergeCallback;
+        return $this;
+    }
+
+    /**
+     * @return callable|null
+     */
+    public function getMergeCallback(): ?callable
+    {
+        return $this->mergeCallback;
+    }
+
+    /**
+     * @param callable|null $mergedSpecsSaveCallback
+     * @return OpenApi
+     */
+    public function setMergedSpecsSaveCallback(?callable $mergedSpecsSaveCallback): OpenApi
+    {
+        $this->mergedSpecsSaveCallback = $mergedSpecsSaveCallback;
+        return $this;
+    }
+
+    /**
+     * @return callable|null
+     */
+    public function getMergedSpecsSaveCallback(): ?callable
+    {
+        return $this->mergedSpecsSaveCallback;
+    }
+}

--- a/src/OpenApiDtoServiceProvider.php
+++ b/src/OpenApiDtoServiceProvider.php
@@ -15,7 +15,7 @@ class OpenApiDtoServiceProvider extends ServiceProvider
      */
     public function register()
     {
-
+        $this->app->singleton('foodkit.open-api', OpenApi::class);
     }
 
     /**

--- a/src/Resolvers/RoutesResolver.php
+++ b/src/Resolvers/RoutesResolver.php
@@ -7,7 +7,7 @@ namespace Foodkit\OpenApiDto\Resolvers;
 use Illuminate\Routing\Route;
 use Illuminate\Support\Collection;
 
-class DocsResolver
+class RoutesResolver
 {
     /** @var Collection|Route[] $routes */
     protected $routes;


### PR DESCRIPTION
## Pull request type

- [X] New feature
- [ ] Bug fix
- [ ] Technical task

## Description

The PR makes it possible to customize how API specs are merged and saved on per-project basis.

Now there is OpenApi facade with methods for setting merge and save callbacks: `setMergeCallback`, `setMergedSpecsSaveCallback`. Application(project) itself defines the logic on how merge and save process should work.